### PR TITLE
Class Registry ignores duplicate matching classes

### DIFF
--- a/sqlobject/classregistry.py
+++ b/sqlobject/classregistry.py
@@ -80,7 +80,7 @@ class ClassRegistry(object):
             other = self.classes[cls.__name__]
             if other.__module__ == cls.__module__:
                 # If the modules match, then ignore the addClass call without
-                # error. Why error out when all we already have what we want?
+                # error. Why error out when we already have what we want?
                 pass
             else:
                 raise ValueError(


### PR DESCRIPTION
This is what Robo and I figured would work for the jobs0 error. We are getting an error sometimes for unknown reasons that the class UserGroup is already in the registry. It appears to be trying to import the same module again, so this change prevents the error if a matching class exists and bypasses the callbacks if so.
