### PR TITLE
NT-85 Add commit and rollback hooks to SQLObject

### DIFF
--- a/sqlobject/__version__.py
+++ b/sqlobject/__version__.py
@@ -4,5 +4,5 @@ major   = 1
 minor   = 6
 micro   = 0
 release_level = 'trunk'
-serial  = 0
+serial  = 1
 version_info = (major, minor, micro, release_level, serial)

--- a/sqlobject/dbconnection.py
+++ b/sqlobject/dbconnection.py
@@ -832,9 +832,14 @@ class Transaction(object):
         self._makeObsolete()
 
     def _send_event(self, signal):
-        sub_caches = [(sub[0], sub[1].allIDs()) for sub in self.cache.allSubCachesByClassNames().items()]
-        if sub_caches:
-            events.send(signal, main.sqlmeta, sub_caches)
+        """
+        Pushes a list of class_names and related ids in cache.
+        :param signal: Type of event signal to use
+        """
+        cached_classes_and_ids = [(class_name, cache.allIDs()) for class_name, cache in
+                                  self.cache.allSubCachesByClassNames().items()]
+        if cached_classes_and_ids:
+            events.send(signal, main.sqlmeta, cached_classes_and_ids)
 
     def __getattr__(self, attr):
         """

--- a/sqlobject/events.py
+++ b/sqlobject/events.py
@@ -192,6 +192,16 @@ class DropTableSignal(Signal):
     after the table has been dropped.
     """
 
+class CommitSignal(Signal):
+    """
+    Called on commit
+    """
+
+class RollbackSignal(Signal):
+    """
+    Called on rollback
+    """
+
 ############################################################
 ## Event Debugging
 ############################################################


### PR DESCRIPTION
- Adding new signal hooks to SQLObject to publish events on Commit / Rollback to help fix the data integrity issue between bazman and engage